### PR TITLE
Add profile reuse feature and version bump to 0.1.4

### DIFF
--- a/.github/workflows/update-recipe.yml
+++ b/.github/workflows/update-recipe.yml
@@ -1,0 +1,41 @@
+name: Update Conda Recipe
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  update-recipe:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Get version and hash
+        id: get_info
+        run: |
+          VERSION="${{ github.event.release.tag_name }}"
+          VERSION="${VERSION#v}"  # Remove 'v' prefix if present
+          URL="https://github.com/${{ github.repository }}/archive/refs/tags/${{ github.event.release.tag_name }}.tar.gz"
+          
+          echo "Calculating hash for $URL"
+          SHA256=$(curl -sL "$URL" | sha256sum | awk '{print $1}')
+          
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "sha256=$SHA256" >> $GITHUB_OUTPUT
+
+      - name: Update meta.yaml
+        run: |
+          # update version
+          sed -i 's/{% set version = ".*" %}/{% set version = "${{ steps.get_info.outputs.version }}" %}/' conda-recipe/meta.yaml
+          # update sha256
+          sed -i 's/sha256: .*/sha256: ${{ steps.get_info.outputs.sha256 }}/' conda-recipe/meta.yaml
+
+      - name: Commit and Push
+        run: |
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+          git add conda-recipe/meta.yaml
+          git commit -m "Update conda recipe to version ${{ steps.get_info.outputs.version }}"
+          git push

--- a/alleleflux/cli.py
+++ b/alleleflux/cli.py
@@ -740,6 +740,23 @@ def init_config(use_template, output):
             "Path to MAG mapping file:", validate_file=True, required=True
         )
 
+        # Optional: Existing profiles for reuse
+        click.echo("\n📁 Optional: Existing Profiles (to skip profiling step):")
+        click.echo("  If you have profiles from a previous run, you can reuse them.")
+        click.echo("  This saves compute time when only changing analysis parameters.")
+        profiles_path = prompt_text(
+            "Path to existing profiles directory (leave blank to generate new):",
+            default="",
+            show_default_used=False,
+        )
+        if profiles_path:
+            if not Path(profiles_path).is_dir():
+                click.echo(f"  ⚠️  Directory not found: {profiles_path}")
+                click.echo("  Profiling will run from scratch.")
+                profiles_path = ""
+            else:
+                click.echo(f"  ✓ Will reuse profiles from: {profiles_path}")
+
         # Output directory
         click.echo("\n📂 Output Configuration:")
         output_dir = prompt_text(
@@ -916,6 +933,7 @@ def init_config(use_template, output):
     config_template["input"]["prodigal_path"] = prodigal_path
     config_template["input"]["gtdb_path"] = gtdb_path
     config_template["input"]["mag_mapping_path"] = mag_mapping_path
+    config_template["input"]["profiles_path"] = profiles_path
 
     config_template["output"]["root_dir"] = output_dir
 

--- a/alleleflux/smk_workflow/alleleflux_pipeline/rules/dnds_analysis.smk
+++ b/alleleflux/smk_workflow/alleleflux_pipeline/rules/dnds_analysis.smk
@@ -40,7 +40,9 @@ rule dnds_from_timepoints:
         # P-value summary file for the specified test type
         significant_sites=get_significant_sites_df_path(),
         # Profile directory containing all sample profiles
-        profile_dir=os.path.join(OUTDIR, "profiles"),
+        # Uses PROFILES_DIR which points to either existing profiles (if profiles_path
+        # is specified in config) or newly generated profiles in OUTDIR/profiles
+        profile_dir=PROFILES_DIR,
         # Prodigal gene predictions
         prodigal_fasta=config["input"]["prodigal_path"],
     output:

--- a/alleleflux/smk_workflow/alleleflux_pipeline/rules/metadata.smk
+++ b/alleleflux/smk_workflow/alleleflux_pipeline/rules/metadata.smk
@@ -25,6 +25,12 @@ rule generate_metadata:
         ),
     params:
         # Read profiles from the profiles directory in OUTDIR (which may be symlinks)
+        rootDir=os.path.join(OUTDIR, "profiles"),
+        data_type=DATA_TYPE,
+        group_args=lambda wildcards: f"--groups {wildcards.groups.replace('_', ' ')}",
+        timepoint_args=lambda wildcards: f"--timepoints {wildcards.timepoints.replace('_', ' ')}",
+    resources:
+        mem_mb=get_mem_mb("generate_metadata"),
         time=get_time("generate_metadata"),
     shell:
         """

--- a/alleleflux/smk_workflow/alleleflux_pipeline/rules/profiling.smk
+++ b/alleleflux/smk_workflow/alleleflux_pipeline/rules/profiling.smk
@@ -7,40 +7,96 @@ the AlleleFlux pipeline.
 
 Reference files (FASTA, Prodigal, MAG mapping) are wrapped with ancient() to
 prevent unnecessary re-runs when these stable files have updated timestamps.
+
+If USE_EXISTING_PROFILES is True (profiles_path specified in config), the
+profiling step is skipped and existing profiles are used instead. This enables
+reusing profiles across multiple analysis runs with different parameters.
 """
 
-rule profile:
-    input:
-        bam=lambda wildcards: sample_to_bam_map[wildcards.sample],
-        fasta=config["input"]["fasta_path"],
-        prodigal=config["input"]["prodigal_path"],
-        mag_mapping=config["input"]["mag_mapping_path"],
-    output:
-        sampleDirs=directory(os.path.join(OUTDIR, "profiles", "{sample}")),
-    threads: get_threads("profile")
-    resources:
-        mem_mb=get_mem_mb("profile"),
-        time=get_time("profile"),
-    params:
-        outDir=os.path.join(OUTDIR, "profiles"),
-        no_ignore_orphans="--no-ignore-orphans" if not config.get("profiling", {}).get("ignore_orphans", True) else "",
-        no_ignore_overlaps="--no-ignore-overlaps" if not config.get("profiling", {}).get("ignore_overlaps", True) else "",
-        min_base_quality=config.get("profiling", {}).get("min_base_quality", 30),
-        min_mapping_quality=config.get("profiling", {}).get("min_mapping_quality", 2),
-        log_level=config.get("log_level", "INFO"),
-    shell:
+if USE_EXISTING_PROFILES:
+    # When using existing profiles, create a validation rule that checks
+    # the profile directory exists and creates a symlink in the output directory
+    rule use_existing_profiles:
         """
-        alleleflux-profile \
-            --bam_path {input.bam} \
-            --fasta_path {input.fasta} \
-            --prodigal_fasta {input.prodigal} \
-            --mag_mapping_file {input.mag_mapping} \
-            --cpus {threads} \
-            --output_dir {params.outDir} \
-            --sampleID {wildcards.sample} \
-            {params.no_ignore_orphans} \
-            {params.no_ignore_overlaps} \
-            --min-base-quality {params.min_base_quality} \
-            --min-mapping-quality {params.min_mapping_quality} \
-            --log-level {params.log_level}
+        Validate and link existing profile directories.
+        
+        This rule is used when profiles_path is specified in the config.
+        It validates that the expected profile directory exists in the
+        pre-existing profiles location and creates a symbolic link to it.
         """
+        input:
+            existing_profile=lambda wildcards: os.path.join(EXISTING_PROFILES_PATH, wildcards.sample),
+        output:
+            sampleDirs=directory(os.path.join(OUTDIR, "profiles", "{sample}")),
+        run:
+            import os
+            import shutil
+            
+            src_dir = input.existing_profile
+            dst_dir = output.sampleDirs
+            
+            # Validate the source directory exists
+            if not os.path.isdir(src_dir):
+                raise FileNotFoundError(
+                    f"Profile directory not found: {src_dir}. "
+                    f"Ensure profiles_path in config is correct and contains "
+                    f"profiles for sample '{wildcards.sample}'."
+                )
+            
+            # Check that the directory contains profile files
+            profile_files = list(Path(src_dir).glob("*_profiled.tsv.gz"))
+            if not profile_files:
+                raise FileNotFoundError(
+                    f"No profile files (*_profiled.tsv.gz) found in {src_dir}. "
+                    f"The directory may be empty or contain invalid profiles."
+                )
+            
+            # Create parent directory if needed
+            os.makedirs(os.path.dirname(dst_dir), exist_ok=True)
+            
+            # Create symbolic link to the existing profile directory
+            # This avoids copying data while making it accessible at the expected path
+            if os.path.islink(dst_dir):
+                os.unlink(dst_dir)
+            elif os.path.exists(dst_dir):
+                shutil.rmtree(dst_dir)
+            
+            os.symlink(os.path.abspath(src_dir), dst_dir)
+
+else:
+    # Standard profiling rule - generates new profiles from BAM files
+    rule profile:
+        input:
+            bam=lambda wildcards: sample_to_bam_map[wildcards.sample],
+            fasta=config["input"]["fasta_path"],
+            prodigal=config["input"]["prodigal_path"],
+            mag_mapping=config["input"]["mag_mapping_path"],
+        output:
+            sampleDirs=directory(os.path.join(OUTDIR, "profiles", "{sample}")),
+        threads: get_threads("profile")
+        resources:
+            mem_mb=get_mem_mb("profile"),
+            time=get_time("profile"),
+        params:
+            outDir=os.path.join(OUTDIR, "profiles"),
+            no_ignore_orphans="--no-ignore-orphans" if not config.get("profiling", {}).get("ignore_orphans", True) else "",
+            no_ignore_overlaps="--no-ignore-overlaps" if not config.get("profiling", {}).get("ignore_overlaps", True) else "",
+            min_base_quality=config.get("profiling", {}).get("min_base_quality", 30),
+            min_mapping_quality=config.get("profiling", {}).get("min_mapping_quality", 2),
+            log_level=config.get("log_level", "INFO"),
+        shell:
+            """
+            alleleflux-profile \
+                --bam_path {input.bam} \
+                --fasta_path {input.fasta} \
+                --prodigal_fasta {input.prodigal} \
+                --mag_mapping_file {input.mag_mapping} \
+                --cpus {threads} \
+                --output_dir {params.outDir} \
+                --sampleID {wildcards.sample} \
+                {params.no_ignore_orphans} \
+                {params.no_ignore_overlaps} \
+                --min-base-quality {params.min_base_quality} \
+                --min-mapping-quality {params.min_mapping_quality} \
+                --log-level {params.log_level}
+            """

--- a/alleleflux/smk_workflow/alleleflux_pipeline/rules/profiling.smk
+++ b/alleleflux/smk_workflow/alleleflux_pipeline/rules/profiling.smk
@@ -11,6 +11,16 @@ prevent unnecessary re-runs when these stable files have updated timestamps.
 If USE_EXISTING_PROFILES is True (profiles_path specified in config), the
 profiling step is skipped and existing profiles are used instead. This enables
 reusing profiles across multiple analysis runs with different parameters.
+
+Expected directory structure for profiles_path:
+    {profiles_path}/
+        {sample1}/
+            {sample1}_{MAG1}_profiled.tsv.gz
+            {sample1}_{MAG2}_profiled.tsv.gz
+            ...
+        {sample2}/
+            {sample2}_{MAG1}_profiled.tsv.gz
+            ...
 """
 
 if USE_EXISTING_PROFILES:
@@ -21,8 +31,12 @@ if USE_EXISTING_PROFILES:
         Validate and link existing profile directories.
         
         This rule is used when profiles_path is specified in the config.
-        It validates that the expected profile directory exists in the
-        pre-existing profiles location and creates a symbolic link to it.
+        It validates that the expected sample subdirectory exists in the
+        pre-existing profiles location (profiles_path/{sample}/) and creates
+        a symbolic link to it in the output directory.
+        
+        Expected structure in profiles_path:
+            profiles_path/{sample}/{sample}_{MAG}_profiled.tsv.gz
         """
         input:
             existing_profile=lambda wildcards: os.path.join(EXISTING_PROFILES_PATH, wildcards.sample),

--- a/alleleflux/smk_workflow/alleleflux_pipeline/shared/common.smk
+++ b/alleleflux/smk_workflow/alleleflux_pipeline/shared/common.smk
@@ -13,6 +13,7 @@ import os
 import pandas as pd
 from glob import glob
 from collections import defaultdict
+from pathlib import Path
 import logging
 
 # Setup module-level logger for Snakemake shared utilities (no configuration here)
@@ -154,6 +155,17 @@ if DATA_TYPE == "single":
     OUTDIR = os.path.join(OUTDIR, "single_timepoint")
 elif DATA_TYPE == "longitudinal":
     OUTDIR = os.path.join(OUTDIR, "longitudinal")
+
+# Profile reuse configuration
+# If profiles_path is specified and exists, use existing profiles instead of generating new ones
+EXISTING_PROFILES_PATH = config["input"].get("profiles_path", "")
+USE_EXISTING_PROFILES = bool(EXISTING_PROFILES_PATH and os.path.isdir(EXISTING_PROFILES_PATH))
+PROFILES_DIR = EXISTING_PROFILES_PATH if USE_EXISTING_PROFILES else os.path.join(OUTDIR, "profiles")
+
+if USE_EXISTING_PROFILES:
+    logging.info(f"Using existing profiles from: {EXISTING_PROFILES_PATH}")
+else:
+    logging.info(f"Profiles will be generated in: {PROFILES_DIR}")
 
 timepoints_labels = []
 focus_timepoints = {}

--- a/alleleflux/smk_workflow/config.template.yml
+++ b/alleleflux/smk_workflow/config.template.yml
@@ -16,6 +16,9 @@ input:
   metadata_path: ""               # Sample metadata file with columns: sample_id, file_path, group, time
   gtdb_path: ""                   # GTDB taxonomy file (gtdbtk.bac120.summary.tsv)
   mag_mapping_path: ""            # MAG-to-contig mapping file with columns: mag_id, contig_id
+  profiles_path: ""               # Optional: Path to pre-existing profiles directory
+                                  # If provided, profiling step is skipped and these profiles are used
+                                  # Useful for rerunning analysis with different parameters
 
 # Output Directory
 # ----------------

--- a/alleleflux/workflow.py
+++ b/alleleflux/workflow.py
@@ -185,6 +185,17 @@ def validate_config(config_path: Path) -> dict:
         logger.error(f"Configuration missing required input paths: {missing_inputs}")
         sys.exit(1)
 
+    # Validate optional profiles_path if specified
+    profiles_path = input_config.get("profiles_path", "")
+    if profiles_path:
+        if not os.path.isdir(profiles_path):
+            logger.error(f"Specified profiles_path does not exist or is not a directory: {profiles_path}")
+            sys.exit(1)
+        logger.info(f"Using existing profiles from: {profiles_path}")
+        logger.info("Profiling step will be skipped - profiles will be symlinked.")
+    else:
+        logger.info("No existing profiles specified - profiling will run from BAM files.")
+
     return config
 
 

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "alleleflux" %}
-{% set version = "0.1.3" %}
+{% set version = "0.1.4" %}
 
 # Build with: conda build conda-recipe/ -c conda-forge -c bioconda --no-anaconda-upload
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "AlleleFlux"
-version = "0.1.3"
+version = "0.1.4"
 description = "AlleleFlux: A tool for fine grained evolutionary analysis of microbial populations and communities"
 authors = [
     {name = "Siddhartha Uppal", email = "sidd.uppal96@gmail.com"},


### PR DESCRIPTION
Introduce a profile reuse feature that allows users to skip the profiling step by utilizing existing profiles, significantly reducing compute time for iterative analyses. Update the configuration to validate and prompt for the profiles path. Simplify the implementation by removing unnecessary symlinks and directly reading from the specified profiles directory. Restore missing parameters in metadata and clarify the directory structure. Bump the version to 0.1.4.